### PR TITLE
[CMAKE] Find WPEFramework though pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,16 @@ else()
 endif()
 
 find_package(WideVine REQUIRED)
+find_package(WPEFramework REQUIRED)
 
 file(GLOB DRM_PLUGIN_INCLUDES *.h)
 
+set(DRM_PLUGIN_INCLUDES
+    ${WPEFRAMEWORK_INCLUDE_DIRS})
+
 set(DRM_PLUGIN_LIBS 
-    -lWPEFrameworkCore
-    ${WIDEVINE_LIBRARIES})
+    ${WIDEVINE_LIBRARIES}
+    ${WPEFRAMEWORK_LIBRARY_WPEFrameworkCore})
 
 set(DRM_PLUGIN_SOURCES 
     HostImplementation.cpp 
@@ -31,7 +35,7 @@ set(DRM_PLUGIN_SOURCES
 # add the library
 add_library(${DRM_PLUGIN_NAME} SHARED ${DRM_PLUGIN_SOURCES})
 target_compile_definitions(${DRM_PLUGIN_NAME} PRIVATE ${WIDEVINE_FLAGS})
-target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${WIDEVINE_INCLUDE_DIRS} ${STAGING_DIR}/usr/include/WPEFramework)
+target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${WIDEVINE_INCLUDE_DIRS} ${DRM_PLUGIN_INCLUDES})
 target_link_libraries(${DRM_PLUGIN_NAME} ${DRM_PLUGIN_LIBS})
 set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES SUFFIX ".drm")
 set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES PREFIX "")

--- a/cmake/FindWPEFramework.cmake
+++ b/cmake/FindWPEFramework.cmake
@@ -1,0 +1,82 @@
+# - Try to find WPEFramework
+# Once done this will define
+#  WPEFRAMEWORK_FOUND - System has WPEFramework
+#  WPEFRAMEWORK_INCLUDE_DIRS - The WPEFramework include directories
+#  WPEFRAMEWORK_LIBRARIES - The libraries needed to use WPEFramework
+#
+# Be extremely careful! WPEFRAMEWORK_PLUGINS_INCLUDE_DIRS and WPEFRAMEWORK_LIBRARIES is already defined in
+# WPEFramework/Source/plugins!!
+# So here we purposely left one underscore away
+
+find_package(PkgConfig)
+pkg_check_modules(PC_WPEFRAMEWORK WPEFramework)
+
+if(PC_WPEFRAMEWORK_FOUND)
+    if(WPEFRAMEWORK_FIND_VERSION AND PC_WPEFRAMEWORK_VERSION)
+        if ("${WPEFRAMEWORK_FIND_VERSION}" VERSION_GREATER "${PC_WPEFRAMEWORK_VERSION}")
+            message(WARNING "Incorrect version, found ${PC_WPEFRAMEWORK_VERSION}, need at least ${WPEFRAMEWORK_FIND_VERSION}, please install correct version ${WPEFRAMEWORK_FIND_VERSION}")
+            set(WPEFRAMEWORK_FOUND_TEXT "Found incorrect version")
+            unset(PC_WPEFRAMEWORK_FOUND)
+        endif()
+    endif()
+else()
+    set(WPEFRAMEWORK_FOUND_TEXT "Not found")
+endif()
+
+if(PC_WPEFRAMEWORK_FOUND)
+    find_path(
+        WPEFRAMEWORK_INCLUDE_DIRS
+        NAMES plugins/plugins.h
+        HINTS ${PC_WPEFRAMEWORK_INCLUDEDIR} ${PC_WPEFRAMEWORK_INCLUDE_DIRS})
+
+    set(WPEFRAMEWORK_LIBS WPEFrameworkPlugins WPEFrameworkCore WPEFrameworkTracing WPEFrameworkProtocols)
+    set(WPEFRAMEWORK_LIBRARY )
+    foreach(LIB ${WPEFRAMEWORK_LIBS})
+        find_library(WPEFRAMEWORK_LIBRARY_${LIB} NAMES ${LIB}
+            HINTS ${PC_WPEFRAMEWORK_LIBDIR} ${PC_WPEFRAMEWORK_LIBRARY_DIRS})
+        list(APPEND WPEFRAMEWORK_LIBRARY ${WPEFRAMEWORK_LIBRARY_${LIB}})
+    endforeach()
+
+    if("${WPEFRAMEWORK_INCLUDE_DIRS}" STREQUAL "" OR "${WPEFRAMEWORK_LIBRARY}" STREQUAL "")
+        set(WPEFRAMEWORK_FOUND_TEXT "Not found")
+    else()
+        set(WPEFRAMEWORK_FOUND_TEXT "Found")
+    endif()
+else()
+    set(WPEFRAMEWORK_FOUND_TEXT "Not found")
+endif()
+
+if (WPEFRAMEWORK_VERBOSE_BUILD)
+    message(STATUS "WPEFramework   : ${WPEFRAMEWORK_FOUND_TEXT}")
+    message(STATUS "  version      : ${PC_WPEFRAMEWORK_VERSION}")
+    message(STATUS "  cflags       : ${PC_WPEFRAMEWORK_CFLAGS}")
+    message(STATUS "  cflags other : ${PC_WPEFRAMEWORK_CFLAGS_OTHER}")
+    message(STATUS "  include dirs : ${PC_WPEFRAMEWORK_INCLUDE_DIRS} ${PC_WPEFRAMEWORK_INCLUDEDIR}")
+    message(STATUS "  lib dirs     : ${PC_WPEFRAMEWORK_LIBRARY_DIRS} ${PC_WPEFRAMEWORK_LIBDIR}")
+    message(STATUS "  include dirs : ${WPEFRAMEWORK_INCLUDE_DIRS}")
+    message(STATUS "  libs         : ${WPEFRAMEWORK_LIBRARY}")
+endif()
+
+set(WPEFRAMEWORK_DEFINITIONS ${PC_WPEFRAMEWORK_PLUGINS_CFLAGS_OTHER})
+set(WPEFRAMEWORK_INCLUDE_DIR ${WPEFRAMEWORK_INCLUDE_DIRS})
+set(WPEFRAMEWORK_LIBRARIES ${WPEFRAMEWORK_LIBRARY})
+set(WPEFRAMEWORK_LIBRARY_DIRS ${PC_WPEFRAMEWORK_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WPEFRAMEWORK DEFAULT_MSG
+    WPEFRAMEWORK_LIBRARIES
+    WPEFRAMEWORK_INCLUDE_DIRS)
+
+if(WPEFRAMEWORK_FOUND)
+else()
+    message(WARNING "Could not find WPEFramework")
+endif()
+
+mark_as_advanced(
+    WPEFRAMEWORK_DEFINITIONS
+    WPEFRAMEWORK_INCLUDE_DIRS
+    WPEFRAMEWORK_LIBRARIES
+    WPEFRAMEWORK_LIBRARY_WPEFrameworkPlugins
+    WPEFRAMEWORK_LIBRARY_WPEFrameworkCore
+    WPEFRAMEWORK_LIBRARY_WPEFrameworkTracing
+    WPEFRAMEWORK_LIBRARY_WPEFrameworkProtocols)


### PR DESCRIPTION
Finding WPEFramework though package config instead of statically including WPEFramework with a ${STAGING_DIR} variable that doesn't work on all build systems.

This fixes the core/core.h include when building in Yocto:
```
| FAILED: CMakeFiles/WideVine.dir/HostImplementation.cpp.o
| /home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++  -DWideVine_EXPORTS -I/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot/usr/include -I/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot -I/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot-native/usr/include/WPEFramework -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot  -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0=/usr/src/debug/wpeframework-ocdm-widevine/3.0+git999-r0 -fdebug-prefix-map=/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot= -fdebug-prefix-map=/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot-native=  -fvisibility-inlines-hidden  -march=armv7ve -mthumb -mfpu=neon-vfpv4 -mfloat-abi=hard -mcpu=cortex-a7 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/wouter/workspace/rpi/oe_master/build-rpi3/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-oe-linux-gnueabi/wpeframework-ocdm-widevine/3.0+git999-r0/recipe-sysroot -std=c++11 -DNDEBUG -fPIC -MD -MT CMakeFiles/WideVine.dir/HostImplementation.cpp.o -MF CMakeFiles/WideVine.dir/HostImplementation.cpp.o.d -o CMakeFiles/WideVine.dir/HostImplementation.cpp.o -c /home/wouter/workspace/rpi/oe_master/build-rpi3/workspace/sources/wpeframework-ocdm-widevine/HostImplementation.cpp
| In file included from /home/wouter/workspace/rpi/oe_master/build-rpi3/workspace/sources/wpeframework-ocdm-widevine/HostImplementation.cpp:1:
| /home/wouter/workspace/rpi/oe_master/build-rpi3/workspace/sources/wpeframework-ocdm-widevine/HostImplementation.h:7:10: fatal error: core/core.h: No such file or directory
|  #include <core/core.h>
|           ^~~~~~~~~~~~~
| compilation terminated.
```